### PR TITLE
feat: adds init scripts

### DIFF
--- a/init/Makefile
+++ b/init/Makefile
@@ -1,0 +1,4 @@
+.SILENT:
+
+install:
+	./setup.sh

--- a/init/README.md
+++ b/init/README.md
@@ -1,0 +1,37 @@
+## Mission Control Initialization scripts
+
+A series of scripts to initialize a dev environment for the Mission Control project.
+
+Installs docker & docker-compose, sources environment variables, and spins up an instance of the Prismatopia backend for Mission Control. A valid .env configuration file and the Mission Control repository are required for these scripts to be of any use besides installing Docker on your machine.
+
+## Get started:
+
+### Linux + MacOS
+
+- NOTE: requires global installation of the prisma cli if you wish to deploy/seed the Prisma layer from the makefile.
+
+```
+npm i -g prisma
+```
+
+1. Clone the Mission Control repo, which contains these init scripts.
+2. Configure your .env to match the credentials in the Mission Control Backend documentation.
+
+```bash
+cd init && make
+```
+
+3. Select your OS [MacOS, Arch, Ubuntu, Debian, CentOS, Fedora]
+4. It's easy now!
+
+#### Windows:
+
+- Message Kevin on Slack
+
+#### Contributors / Testers:
+
+Special thanks to [ElijahMcKay](https://github.com/ElijahMcKay), [fresocodes](https://github.com/frescocodes), & [judson00](https://github.com/judson00).
+
+---
+
+The Ubuntu / Debian / CentOS / Fedora installation uses the `get.docker.com` install script which can be found [here](https://github.com/docker/docker-install).

--- a/init/arch.sh
+++ b/init/arch.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+install_packages() {
+	read -r -p "Install Docker? [y/N] " answer
+	if [[ "$answer" != y ]] && [[ "$answer" != Y ]]; then
+		echo -e "\nSkipping Docker Install..."
+	else
+		echo -e "\nInstalling required packages for Arch..."
+
+		declare -a packages=(
+		"docker"
+		"docker-compose"
+		)
+
+	sudo pacman -Syu ${packages[@]}
+
+	echo -e "DONE.\n"
+	fi
+}
+
+enable_docker() {
+	read -r -p "Start and enable Docker? [y/N] " answer
+	if [[ "$answer" != y ]] && [[ "$answer" != Y ]]; then
+		echo -e "\nSkipping Docker systemctl setup..."
+	else
+		echo -e "\nStarting Docker through systemctl..."
+		systemctl start docker
+
+		echo -e "\nEnabling Docker through systemctl..."
+		systemctl enable docker
+
+		echo -e "DONE.\n"
+	fi
+}
+
+configure_docker() {
+	read -r -p "Manage Docker as a non-root user? [y/N] " answer
+	if [[ "$answer" != y ]] && [[ "$answer" != Y ]]; then
+		echo -e "\nSkipping Docker non-root configuration..."
+	else
+		echo -e "\nAdding 'docker' group..."
+		sudo groupadd docker
+
+		echo -e "\nAdding user $USER to 'docker' group..."
+		sudo usermod -aG docker "$USER"
+
+		echo -e "\nDone. Logout and back in to refresh groups.\n"
+	fi
+}
+
+install_packages
+enable_docker
+configure_docker

--- a/init/get-docker.sh
+++ b/init/get-docker.sh
@@ -1,0 +1,476 @@
+#!/bin/sh
+set -e
+
+# This script is meant for quick & easy install via:
+#   $ curl -fsSL https://get.docker.com -o get-docker.sh
+#   $ sh get-docker.sh
+#
+# For test builds (ie. release candidates):
+#   $ curl -fsSL https://test.docker.com -o test-docker.sh
+#   $ sh test-docker.sh
+#
+# NOTE: Make sure to verify the contents of the script
+#       you downloaded matches the contents of install.sh
+#       located at https://github.com/docker/docker-install
+#       before executing.
+#
+# Git commit from https://github.com/docker/docker-install when
+# the script was uploaded (Should only be modified by upload job):
+SCRIPT_COMMIT_SHA="f45d7c11389849ff46a6b4d94e0dd1ffebca32c1"
+
+
+# The channel to install from:
+#   * nightly
+#   * test
+#   * stable
+#   * edge (deprecated)
+DEFAULT_CHANNEL_VALUE="stable"
+if [ -z "$CHANNEL" ]; then
+	CHANNEL=$DEFAULT_CHANNEL_VALUE
+fi
+
+DEFAULT_DOWNLOAD_URL="https://download.docker.com"
+if [ -z "$DOWNLOAD_URL" ]; then
+	DOWNLOAD_URL=$DEFAULT_DOWNLOAD_URL
+fi
+
+DEFAULT_REPO_FILE="docker-ce.repo"
+if [ -z "$REPO_FILE" ]; then
+	REPO_FILE="$DEFAULT_REPO_FILE"
+fi
+
+mirror=''
+DRY_RUN=${DRY_RUN:-}
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--mirror)
+			mirror="$2"
+			shift
+			;;
+		--dry-run)
+			DRY_RUN=1
+			;;
+		--*)
+			echo "Illegal option $1"
+			;;
+	esac
+	shift $(( $# > 0 ? 1 : 0 ))
+done
+
+case "$mirror" in
+	Aliyun)
+		DOWNLOAD_URL="https://mirrors.aliyun.com/docker-ce"
+		;;
+	AzureChinaCloud)
+		DOWNLOAD_URL="https://mirror.azure.cn/docker-ce"
+		;;
+esac
+
+command_exists() {
+	command -v "$@" > /dev/null 2>&1
+}
+
+is_dry_run() {
+	if [ -z "$DRY_RUN" ]; then
+		return 1
+	else
+		return 0
+	fi
+}
+
+deprecation_notice() {
+	distro=$1
+	date=$2
+	echo
+	echo "DEPRECATION WARNING:"
+	echo "    The distribution, $distro, will no longer be supported in this script as of $date."
+	echo "    If you feel this is a mistake please submit an issue at https://github.com/docker/docker-install/issues/new"
+	echo
+	sleep 10
+}
+
+get_distribution() {
+	lsb_dist=""
+	# Every system that we officially support has /etc/os-release
+	if [ -r /etc/os-release ]; then
+		lsb_dist="$(. /etc/os-release && echo "$ID")"
+	fi
+	# Returning an empty string here should be alright since the
+	# case statements don't act unless you provide an actual value
+	echo "$lsb_dist"
+}
+
+add_debian_backport_repo() {
+	debian_version="$1"
+	backports="deb http://ftp.debian.org/debian $debian_version-backports main"
+	if ! grep -Fxq "$backports" /etc/apt/sources.list; then
+		(set -x; $sh_c "echo \"$backports\" >> /etc/apt/sources.list")
+	fi
+}
+
+echo_docker_as_nonroot() {
+	if is_dry_run; then
+		return
+	fi
+	if command_exists docker && [ -e /var/run/docker.sock ]; then
+		(
+			set -x
+			$sh_c 'docker version'
+		) || true
+	fi
+	your_user=your-user
+	[ "$user" != 'root' ] && your_user="$user"
+	# intentionally mixed spaces and tabs here -- tabs are stripped by "<<-EOF", spaces are kept in the output
+	echo "If you would like to use Docker as a non-root user, you should now consider"
+	echo "adding your user to the \"docker\" group with something like:"
+	echo
+	echo "  sudo usermod -aG docker $your_user"
+	echo
+	echo "Remember that you will have to log out and back in for this to take effect!"
+	echo
+	echo "WARNING: Adding a user to the \"docker\" group will grant the ability to run"
+	echo "         containers which can be used to obtain root privileges on the"
+	echo "         docker host."
+	echo "         Refer to https://docs.docker.com/engine/security/security/#docker-daemon-attack-surface"
+	echo "         for more information."
+
+}
+
+# Check if this is a forked Linux distro
+check_forked() {
+
+	# Check for lsb_release command existence, it usually exists in forked distros
+	if command_exists lsb_release; then
+		# Check if the `-u` option is supported
+		set +e
+		lsb_release -a -u > /dev/null 2>&1
+		lsb_release_exit_code=$?
+		set -e
+
+		# Check if the command has exited successfully, it means we're in a forked distro
+		if [ "$lsb_release_exit_code" = "0" ]; then
+			# Print info about current distro
+			cat <<-EOF
+			You're using '$lsb_dist' version '$dist_version'.
+			EOF
+
+			# Get the upstream release info
+			lsb_dist=$(lsb_release -a -u 2>&1 | tr '[:upper:]' '[:lower:]' | grep -E 'id' | cut -d ':' -f 2 | tr -d '[:space:]')
+			dist_version=$(lsb_release -a -u 2>&1 | tr '[:upper:]' '[:lower:]' | grep -E 'codename' | cut -d ':' -f 2 | tr -d '[:space:]')
+
+			# Print info about upstream distro
+			cat <<-EOF
+			Upstream release is '$lsb_dist' version '$dist_version'.
+			EOF
+		else
+			if [ -r /etc/debian_version ] && [ "$lsb_dist" != "ubuntu" ] && [ "$lsb_dist" != "raspbian" ]; then
+				if [ "$lsb_dist" = "osmc" ]; then
+					# OSMC runs Raspbian
+					lsb_dist=raspbian
+				else
+					# We're Debian and don't even know it!
+					lsb_dist=debian
+				fi
+				dist_version="$(sed 's/\/.*//' /etc/debian_version | sed 's/\..*//')"
+				case "$dist_version" in
+					10)
+						dist_version="buster"
+					;;
+					9)
+						dist_version="stretch"
+					;;
+					8|'Kali Linux 2')
+						dist_version="jessie"
+					;;
+				esac
+			fi
+		fi
+	fi
+}
+
+semverParse() {
+	major="${1%%.*}"
+	minor="${1#$major.}"
+	minor="${minor%%.*}"
+	patch="${1#$major.$minor.}"
+	patch="${patch%%[-.]*}"
+}
+
+ee_notice() {
+	echo
+	echo
+	echo "  WARNING: $1 is now only supported by Docker EE"
+	echo "           Check https://store.docker.com for information on Docker EE"
+	echo
+	echo
+}
+
+do_install() {
+	echo "# Executing docker install script, commit: $SCRIPT_COMMIT_SHA"
+
+	if command_exists docker; then
+		docker_version="$(docker -v | cut -d ' ' -f3 | cut -d ',' -f1)"
+		MAJOR_W=1
+		MINOR_W=10
+
+		semverParse "$docker_version"
+
+		shouldWarn=0
+		if [ "$major" -lt "$MAJOR_W" ]; then
+			shouldWarn=1
+		fi
+
+		if [ "$major" -le "$MAJOR_W" ] && [ "$minor" -lt "$MINOR_W" ]; then
+			shouldWarn=1
+		fi
+
+		cat >&2 <<-'EOF'
+			Warning: the "docker" command appears to already exist on this system.
+
+			If you already have Docker installed, this script can cause trouble, which is
+			why we're displaying this warning and provide the opportunity to cancel the
+			installation.
+
+			If you installed the current Docker package using this script and are using it
+		EOF
+
+		if [ $shouldWarn -eq 1 ]; then
+			cat >&2 <<-'EOF'
+			again to update Docker, we urge you to migrate your image store before upgrading
+			to v1.10+.
+
+			You can find instructions for this here:
+			https://github.com/docker/docker/wiki/Engine-v1.10.0-content-addressability-migration
+			EOF
+		else
+			cat >&2 <<-'EOF'
+			again to update Docker, you can safely ignore this message.
+			EOF
+		fi
+
+		cat >&2 <<-'EOF'
+
+			You may press Ctrl+C now to abort this script.
+		EOF
+		( set -x; sleep 20 )
+	fi
+
+	user="$(id -un 2>/dev/null || true)"
+
+	sh_c='sh -c'
+	if [ "$user" != 'root' ]; then
+		if command_exists sudo; then
+			sh_c='sudo -E sh -c'
+		elif command_exists su; then
+			sh_c='su -c'
+		else
+			cat >&2 <<-'EOF'
+			Error: this installer needs the ability to run commands as root.
+			We are unable to find either "sudo" or "su" available to make this happen.
+			EOF
+			exit 1
+		fi
+	fi
+
+	if is_dry_run; then
+		sh_c="echo"
+	fi
+
+	# perform some very rudimentary platform detection
+	lsb_dist=$( get_distribution )
+	lsb_dist="$(echo "$lsb_dist" | tr '[:upper:]' '[:lower:]')"
+
+	case "$lsb_dist" in
+
+		ubuntu)
+			if command_exists lsb_release; then
+				dist_version="$(lsb_release --codename | cut -f2)"
+			fi
+			if [ -z "$dist_version" ] && [ -r /etc/lsb-release ]; then
+				dist_version="$(. /etc/lsb-release && echo "$DISTRIB_CODENAME")"
+			fi
+		;;
+
+		debian|raspbian)
+			dist_version="$(sed 's/\/.*//' /etc/debian_version | sed 's/\..*//')"
+			case "$dist_version" in
+				10)
+					dist_version="buster"
+				;;
+				9)
+					dist_version="stretch"
+				;;
+				8)
+					dist_version="jessie"
+				;;
+			esac
+		;;
+
+		centos)
+			if [ -z "$dist_version" ] && [ -r /etc/os-release ]; then
+				dist_version="$(. /etc/os-release && echo "$VERSION_ID")"
+			fi
+		;;
+
+		rhel|ol|sles)
+			ee_notice "$lsb_dist"
+			exit 1
+			;;
+
+		*)
+			if command_exists lsb_release; then
+				dist_version="$(lsb_release --release | cut -f2)"
+			fi
+			if [ -z "$dist_version" ] && [ -r /etc/os-release ]; then
+				dist_version="$(. /etc/os-release && echo "$VERSION_ID")"
+			fi
+		;;
+
+	esac
+
+	# Check if this is a forked Linux distro
+	check_forked
+
+	# Run setup for each distro accordingly
+	case "$lsb_dist" in
+		ubuntu|debian|raspbian)
+			pre_reqs="apt-transport-https ca-certificates curl"
+			if [ "$lsb_dist" = "debian" ]; then
+				# libseccomp2 does not exist for debian jessie main repos for aarch64
+				if [ "$(uname -m)" = "aarch64" ] && [ "$dist_version" = "jessie" ]; then
+					add_debian_backport_repo "$dist_version"
+				fi
+			fi
+
+			if ! command -v gpg > /dev/null; then
+				pre_reqs="$pre_reqs gnupg"
+			fi
+			apt_repo="deb [arch=$(dpkg --print-architecture)] $DOWNLOAD_URL/linux/$lsb_dist $dist_version $CHANNEL"
+			(
+				if ! is_dry_run; then
+					set -x
+				fi
+				$sh_c 'apt-get update -qq >/dev/null'
+				$sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $pre_reqs >/dev/null"
+				$sh_c "curl -fsSL \"$DOWNLOAD_URL/linux/$lsb_dist/gpg\" | apt-key add -qq - >/dev/null"
+				$sh_c "echo \"$apt_repo\" > /etc/apt/sources.list.d/docker.list"
+				$sh_c 'apt-get update -qq >/dev/null'
+			)
+			pkg_version=""
+			if [ -n "$VERSION" ]; then
+				if is_dry_run; then
+					echo "# WARNING: VERSION pinning is not supported in DRY_RUN"
+				else
+					# Will work for incomplete versions IE (17.12), but may not actually grab the "latest" if in the test channel
+					pkg_pattern="$(echo "$VERSION" | sed "s/-ce-/~ce~.*/g" | sed "s/-/.*/g").*-0~$lsb_dist"
+					search_command="apt-cache madison 'docker-ce' | grep '$pkg_pattern' | head -1 | awk '{\$1=\$1};1' | cut -d' ' -f 3"
+					pkg_version="$($sh_c "$search_command")"
+					echo "INFO: Searching repository for VERSION '$VERSION'"
+					echo "INFO: $search_command"
+					if [ -z "$pkg_version" ]; then
+						echo
+						echo "ERROR: '$VERSION' not found amongst apt-cache madison results"
+						echo
+						exit 1
+					fi
+					search_command="apt-cache madison 'docker-ce-cli' | grep '$pkg_pattern' | head -1 | awk '{\$1=\$1};1' | cut -d' ' -f 3"
+					# Don't insert an = for cli_pkg_version, we'll just include it later
+					cli_pkg_version="$($sh_c "$search_command")"
+					pkg_version="=$pkg_version"
+				fi
+			fi
+			(
+				if ! is_dry_run; then
+					set -x
+				fi
+				if [ -n "$cli_pkg_version" ]; then
+					$sh_c "apt-get install -y -qq --no-install-recommends docker-ce-cli=$cli_pkg_version >/dev/null"
+				fi
+				$sh_c "apt-get install -y -qq --no-install-recommends docker-ce$pkg_version >/dev/null"
+			)
+			echo_docker_as_nonroot
+			exit 0
+			;;
+		centos|fedora)
+			yum_repo="$DOWNLOAD_URL/linux/$lsb_dist/$REPO_FILE"
+			if ! curl -Ifs "$yum_repo" > /dev/null; then
+				echo "Error: Unable to curl repository file $yum_repo, is it valid?"
+				exit 1
+			fi
+			if [ "$lsb_dist" = "fedora" ]; then
+				pkg_manager="dnf"
+				config_manager="dnf config-manager"
+				enable_channel_flag="--set-enabled"
+				disable_channel_flag="--set-disabled"
+				pre_reqs="dnf-plugins-core"
+				pkg_suffix="fc$dist_version"
+			else
+				pkg_manager="yum"
+				config_manager="yum-config-manager"
+				enable_channel_flag="--enable"
+				disable_channel_flag="--disable"
+				pre_reqs="yum-utils"
+				pkg_suffix="el"
+			fi
+			(
+				if ! is_dry_run; then
+					set -x
+				fi
+				$sh_c "$pkg_manager install -y -q $pre_reqs"
+				$sh_c "$config_manager --add-repo $yum_repo"
+
+				if [ "$CHANNEL" != "stable" ]; then
+					$sh_c "$config_manager $disable_channel_flag docker-ce-*"
+					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
+				fi
+				$sh_c "$pkg_manager makecache"
+			)
+			pkg_version=""
+			if [ -n "$VERSION" ]; then
+				if is_dry_run; then
+					echo "# WARNING: VERSION pinning is not supported in DRY_RUN"
+				else
+					pkg_pattern="$(echo "$VERSION" | sed "s/-ce-/\\\\.ce.*/g" | sed "s/-/.*/g").*$pkg_suffix"
+					search_command="$pkg_manager list --showduplicates 'docker-ce' | grep '$pkg_pattern' | tail -1 | awk '{print \$2}'"
+					pkg_version="$($sh_c "$search_command")"
+					echo "INFO: Searching repository for VERSION '$VERSION'"
+					echo "INFO: $search_command"
+					if [ -z "$pkg_version" ]; then
+						echo
+						echo "ERROR: '$VERSION' not found amongst $pkg_manager list results"
+						echo
+						exit 1
+					fi
+					search_command="$pkg_manager list --showduplicates 'docker-ce-cli' | grep '$pkg_pattern' | tail -1 | awk '{print \$2}'"
+					# It's okay for cli_pkg_version to be blank, since older versions don't support a cli package
+					cli_pkg_version="$($sh_c "$search_command" | cut -d':' -f 2)"
+					# Cut out the epoch and prefix with a '-'
+					pkg_version="-$(echo "$pkg_version" | cut -d':' -f 2)"
+				fi
+			fi
+			(
+				if ! is_dry_run; then
+					set -x
+				fi
+				# install the correct cli version first
+				if [ -n "$cli_pkg_version" ]; then
+					$sh_c "$pkg_manager install -y -q docker-ce-cli-$cli_pkg_version"
+				fi
+				$sh_c "$pkg_manager install -y -q docker-ce$pkg_version"
+			)
+			echo_docker_as_nonroot
+			exit 0
+			;;
+		*)
+			echo
+			echo "ERROR: Unsupported distribution '$lsb_dist'"
+			echo
+			exit 1
+			;;
+	esac
+	exit 1
+}
+
+# wrapped up in a function so that we have some protection against only getting
+# half the file during "curl | sh"
+do_install

--- a/init/linux.sh
+++ b/init/linux.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+get_docker() {
+	read -r -p "Install Docker? [y/N] " answer
+	if [[ "$answer" != y ]] && [[ "$answer" != Y ]]; then
+		echo -e "\nSkipping Docker setup...\n"
+	else
+		sh ./get-docker.sh
+	fi
+}
+
+enable_docker() {
+	read -r -p "Start and enable Docker? [y/N] " answer
+	if [[ "$answer" != y ]] && [[ "$answer" != Y ]]; then
+		echo -e "\nSkipping Docker systemctl setup...\n"
+	else
+		echo -e "\nStarting Docker through systemctl..."
+		systemctl start docker
+
+		echo -e "\nEnabling Docker through systemctl..."
+		systemctl enable docker
+
+		echo -e "DONE.\n"
+	fi
+}
+
+configure_docker() {
+	read -r -p "Manage Docker as a non-root user? [y/N] " answer
+	if [[ "$answer" != y ]] && [[ "$answer" != Y ]]; then
+		echo -e "\nSkipping Docker non-root configuration..."
+	else
+		echo -e "\nAdding 'docker' group..."
+		sudo groupadd docker
+
+		echo -e "\nAdding user $USER to 'docker' group..."
+		sudo usermod -aG docker "$USER"
+
+		echo -e "\nDone. Logout and back in to refresh groups.\n"
+	fi
+}
+
+install_dockerc() {
+	read -r -p "Install docker-compose? [y/N] " answer
+	if [[ "$answer" != y ]] && [[ "$answer" != Y ]]; then
+		echo -e "\nSkipping docker-compose install"
+	else
+		sudo curl -L "https://github.com/docker/compose/releases/download/1.25.3/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+		sudo chmod +x /usr/local/bin/docker-compose
+	fi
+	}
+
+get_docker
+enable_docker
+configure_docker
+install_dockerc

--- a/init/mac.sh
+++ b/init/mac.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+install_packages() {
+	read -r -p "\nInstall Docker & docker-compose? [y/N] " answer
+	if [[ "$answer" != y ]] && [[ "$answer" != Y ]]; then
+		echo -e "\nSkipping Docker systemctl setup...\n"
+	else
+		echo -e "\nInstalling Docker for MacOS..."
+
+		declare -a packages=(
+			"docker"
+			"docker-compose"
+		)
+
+		brew install ${packages[@]}
+		brew cask install docker
+
+		echo -e "DONE.\n"
+	fi
+}
+
+setup_homebrew() {
+	read -r -p "\nInstall Homebrew? [y/N] " answer
+	if [[ "$answer" != y ]] && [[ "$answer" != Y ]]; then
+		echo -e "\nSkipping Homebrew setup...\n"
+	else
+		if [[ ! $(which brew) ]] && [[ ! $(brew --version &> /dev/null) ]]; then
+			echo -e "\nCould not find existing HOMEBREW installation."
+			echo -e "\nNow installing..."
+			/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+		fi
+	fi
+}
+
+setup_macos() {
+	echo -e "\nSetting up MacOS config...\n"
+
+	setup_homebrew
+	install_packages
+
+	open /Applications/Docker.app
+	echo -e "\nStarting the Docker daemon, this could take a while"
+	echo -e "Check your task bar to make sure it's running before continuing"
+}
+
+setup_macos

--- a/init/mc.sh
+++ b/init/mc.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+containers() {
+	echo -e "\nRunning Mission Control backend"
+	cd ../ && \
+	echo -e "\nSourcing .env"
+	source sourceme.sh && \
+	echo -e "\nStarting container..."
+	docker-compose up --build -d
+	echo
+}
+
+
+run_mc() {
+	read -r -p "Start Mission Control container? [y/N] " answer
+	if [[ "$answer" != y ]] && [[ "$answer" != Y ]]; then
+		echo -e "\nSkipping Mission Control deployment..."
+	else
+		containers
+		# Deploy Prisma
+		read -r -p "Deploy prisma? [y/N] " answer
+		if [[ "$answer" != y ]] && [[ "$answer" != Y ]]; then
+			echo -e "\nNOTE: Prisma model has not been deployed..."
+		else
+			prisma deploy
+			echo
+			# Run Prisma Seed
+			read -r -p "Run Seed? [y/N] " answer
+			if [[ "$answer" != y ]] && [[ "$answer" != Y ]]; then
+				echo -e "\nNOTE: Database is EMPTY"
+			else
+				prisma reset --force && prisma seed
+				echo
+				echo -e "\nApollo Server listening on port 8000"
+				echo -e "Prisma listening on port 7000"
+				echo -e "Happy hacking from Labs 19 <3\n"
+			fi
+		fi
+	fi
+}
+
+run_mc

--- a/init/setup.sh
+++ b/init/setup.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+confirm() {
+	read -r -p "Proceed with setup? for "$2" [y/N] " answer
+	if [[ "$answer" != y ]] && [[ "$answer" != Y ]]; then
+		echo "Cancelling setup"
+		echo "Now exiting"
+		exit
+	else
+		./"$1".sh
+	fi
+}
+
+declare -a options=(
+	"Configure for MacOS"
+	"Configure for Ubuntu / Debian / CentOS / Fedora"
+	"Configure for Arch"
+	"Deploy Mission Control"
+	"Exit"
+)
+
+COLUMNS=12
+
+PS3="Please choose an option: "
+
+select opt in "${options[@]}"
+do
+	case $opt in
+		"Configure for MacOS")
+			confirm "mac" "MacOS"
+			break
+			;;
+		"Configure for Ubuntu / Debian / CentOS / Fedora")
+			confirm "linux"
+			break
+			;;
+		"Configure for Arch")
+			confirm "arch" "Arch"
+			break
+			;;
+		"Deploy Mission Control")
+			confirm "mc" "Mission Control"
+			break
+			;;
+		"Exit")
+			echo "Stopping..."
+			break
+			;;
+		*) echo "invalid option $REPLY";;
+	esac
+done


### PR DESCRIPTION
see: [init-scripts](https://github.com/gebhartn/init-testing) for history.

* Install Docker MacOS
* Install Docker Arch / Arch-derived
* Install Docker supported Linux

Linux users can optionally select to manage Docker
as a user rather than as root. There are some security
risks associated with this, as noted in the docs.

MacOS users must wait until the Docker application has
initialized before they may continue to pull the image
or spin up any containers.

* Initialize Docker containers for Prismatopia
* Optionally deploy & seed Prisma data layer