### PR TITLE
Cleaned up nodemon implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,10 @@ init: clean
 # =================================================================
 
 prisma-generate:
-	@echo
-	@echo Generating Prisma schema
-	@cd prisma && \
-	prisma generate
+	@export $$(cat .env | xargs)			&& \
+	 echo															&& \
+	 echo Generating Prisma schema		&& \
+	 cd prisma && prisma generate
 
 local-prisma-deploy:
 	@echo

--- a/apollo/Dockerfile
+++ b/apollo/Dockerfile
@@ -1,18 +1,21 @@
-# ======================================================
-# Get's node image with the production deps
-# ======================================================
+# ============================================================================================================
+# Create an image containing only the production dependencies
+# ============================================================================================================
 FROM node:12-alpine AS deps
 WORKDIR /app
+
 COPY package.json npm-shrinkwrap.json ./
 RUN npm install --production --silent
 
 
-# ======================================================
-# Builds the final image from the previous two
-# ======================================================
+# ============================================================================================================
+# Build final image using the node_modules from the 'dep' image
+# ============================================================================================================
 FROM node:12-alpine
 WORKDIR /app
+
 COPY --from=deps /app/node_modules ./node_modules/
 COPY ./src/ ./
+
 CMD [ "node", "index.js" ]
 EXPOSE 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,10 @@ services:
   apollo:
     build:
       context: ./apollo
-      dockerfile: Dockerfile.dev
-    command: nodemon src/index.js
+      dockerfile: Dockerfile
+    command: sh -c "npm install -g nodemon && nodemon src/index.js"
     volumes:
-      - ./apollo:/app
+      - ./apollo/src:/app/src
     ports:
       - '${APOLLO_LISTEN_PORT:-8000}:${APOLLO_LISTEN_PORT:-8000}'
     environment:
@@ -20,7 +20,7 @@ services:
       PRISMA_SECRET: ${PRISMA_SECRET:?You must specify PRISMA_SECRET}
 
       OAUTH_TOKEN_ENDPOINT: ${OAUTH_TOKEN_ENDPOINT:?You must specify OAUTH_TOKEN_ENDPOINT}
-      OAUTH_CLIENT_ID: ${OAUTH_CLIENT_ID:?You must specify 0AUTH_CLIENT_ID}
+      OAUTH_CLIENT_ID: ${OAUTH_CLIENT_ID:?You must specify OAUTH_CLIENT_ID}
 
   # The Prisma service
   prisma:


### PR DESCRIPTION
# Description

Fixed the use of nodemon so it doesn't require a seperate Dockerfile for Apollo. This will allow the use of the same image during local development as well as in production, much more safer.