### PR TITLE
Update Resolvers

### DIFF
--- a/apollo/src/resolvers/Mutation.js
+++ b/apollo/src/resolvers/Mutation.js
@@ -109,10 +109,11 @@ const createPerson = (parent, args, context) => {
 // and takes email strings for attendedBy and Author
 // ID input will have to be a project ID
 const createNote = async (parent, args, context) => {
-  const { topic, content, attendedBy, rating, id, notification } = args;
+  const { topic, content, attendedBy, rating, id, notification, privateNote } = args;
   const note = {
     topic,
     content,
+    privateNote,
     author: { connect: { email: context.user.email } },
     attendedBy: {
       connect: attendedBy.map(email => {
@@ -159,7 +160,7 @@ const createNote = async (parent, args, context) => {
 // Takes in the same args are create note AND a specific note ID
 // uses note id to pull attendees to remove them and then pushes new data
 const updateNote = async (parent, args, context) => {
-  const { topic, content, attendedBy, rating, id } = args;
+  const { topic, content, attendedBy, rating, id, privateNote } = args;
 
   // pulls the attendee data on the note where: id
   const oldAttendees = await context.prisma.note({ id }).attendedBy();
@@ -174,6 +175,7 @@ const updateNote = async (parent, args, context) => {
       data: {
         topic,
         rating,
+        privateNote,
         content,
         attendedBy: {
           // cleares the attendedBy field so it can be refill with new inputs

--- a/apollo/src/schema.js
+++ b/apollo/src/schema.js
@@ -42,6 +42,7 @@ const typeDefs = gql`
     createNote(
       topic: String!
       content: String!
+      privateNote: Boolean
       attendedBy: [String!]!
       id: ID!
       rating: Int!
@@ -50,6 +51,7 @@ const typeDefs = gql`
     updateNote(
       topic: String
       content: String
+      privateNote: Boolean
       attendedBy: [String]
       oldAttendees: [String]
       id: ID!


### PR DESCRIPTION
# Description
Updated ```updateNote()``` and ```createNote()``` mutations and resolvers to support toggling if a note is or is not private.

Fixes # (issue)
* Now only Managers can edit a note

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Change Status
- [x] Complete, but not tested (may need new tests)

# Checklist
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] My changes generate no new warnings
