### PR TITLE
The Quality Hub FE has no Latest Default Snapshot

### DIFF
--- a/prisma/seeds/prisma-seed.graphql
+++ b/prisma/seeds/prisma-seed.graphql
@@ -283,10 +283,6 @@ mutation {
             Ccrepos: {
               create: [
                 {
-                  name: "quality-hub-core-fe"
-                  CCId: "5dcc14feb1c7b80f020081d5"
-                }
-                {
                   name: "quality-hub-core-be"
                   CCId: "5dcc1505234ac30f97008afc"
                 }


### PR DESCRIPTION
Removes the Quality HUB FE from the seeds, this repository has no default snapshot so its value is null which throws an error in how we're currently handling things.

# Description

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

