### PR TITLE
Patchwork/adds display to create status

### DIFF
--- a/apollo/src/resolvers/Mutation.js
+++ b/apollo/src/resolvers/Mutation.js
@@ -79,9 +79,10 @@ const createLabel = (parent, args, context) => {
 //Create a new Status Column, needs Program ID and name
 //will populate to all projects
 const createStatus = async (parent, args, context) => {
-  const { name, id } = args;
+  const { name, display, id } = args;
   const getProjects = await context.prisma.projects();
   const status = context.prisma.createStatus({
+    display,
     name,
     projects: { connect: getProjects.map(({ id }) => ({ id })) },
     program: { connect: { id } },
@@ -304,4 +305,4 @@ module.exports = {
   deleteStatus,
   updateSelectedLabel,
   disconnectSelectedLabel,
-}
+};

--- a/apollo/src/schema.js
+++ b/apollo/src/schema.js
@@ -39,10 +39,10 @@ const typeDefs = gql`
       labels: [String]
     ): Status!
     updateLabel(id: ID!, name: String, color: String): Label!
-    updateSelectedLabel(id: ID!, selected: ID!): Label!
+    updateSelectedLabel(id: ID!, selected: ID!, columnId: String): Label!
     deleteLabel(id: ID!, columnId: String): Label!
     updateStatus(id: ID!, name: String, display: Boolean): Status!
-    disconnectSelectedLabel(id: ID!, selected: ID!, columnId: String): Status!
+    disconnectSelectedLabel(id: ID!, selected: ID!, columnId: String): Label!
     deleteStatus(id: ID!): Status!
     createPerson(name: String!, email: String!): Person!
     addProjectMember(id: ID!, email: String!): Person!

--- a/apollo/src/schema.js
+++ b/apollo/src/schema.js
@@ -32,7 +32,12 @@ const typeDefs = gql`
     createProduct(name: String!, id: ID!): Product!
     createProject(name: String!, id: ID!): Project!
     createLabel(name: String!, color: String!, id: ID!): Label!
-    createStatus(name: String!, projects: [String], id: ID!): Status!
+    createStatus(
+      name: String!
+      projects: [String]
+      display: Boolean
+      id: ID!
+    ): Status!
     updateLabel(id: ID!, name: String, color: String): Label!
     updateSelectedLabel(id: ID!, selected: ID!, columnId: String): Label!
     deleteLabel(id: ID!, columnId: String): Label!


### PR DESCRIPTION
# Description
Adds display as an arg to the createStatus mutation to work with the [patchwork/styles-and-cleanup](https://github.com/Lambda-School-Labs/mission-control-fe/pull/277)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [ ] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [ ] Test A
- [ ] Test B

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
